### PR TITLE
Added Health Check Endpoint

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -237,6 +237,7 @@ uvicorn main:app --reload
     <th>Endpoint</th>
     <th>Method</th>
     <th>Description</th>
+    <th>Health</th>
   </tr>
   <tr>
     <td><code>/upload/</code></td>
@@ -257,6 +258,11 @@ uvicorn main:app --reload
     <td><code>/compare/{product_id}</code></td>
     <td>GET</td>
     <td>Compare products</td>
+  </tr>
+  <tr>
+    <td><code>/health</code></td>
+    <td>GET</td>
+    <td>Check health status of DB</td>
   </tr>
 </table>
 

--- a/Readme.md
+++ b/Readme.md
@@ -237,7 +237,6 @@ uvicorn main:app --reload
     <th>Endpoint</th>
     <th>Method</th>
     <th>Description</th>
-    <th>Health</th>
   </tr>
   <tr>
     <td><code>/upload/</code></td>


### PR DESCRIPTION
## Description
This PR introduces a /health endpoint in the FastAPI application to monitor the MongoDB connection status and response time. This helps ensure the application is operating as expected and provides insight into the database's health.

## Related Issue
Fixes #12 

## Motivation and Context
- Check database connectivity
- Report connection status
- Add response time metrics

## How Has This Been Tested?
Go to the /health route
- Healthy Scenario: Verified the endpoint responds with status: healthy when MongoDB is connected.
- Unhealthy Scenario: Simulated MongoDB connection issues to verify the endpoint reports an error with status: unhealthy.


## Screenshots (if appropriate):
https://github.com/user-attachments/assets/62399c19-8ac4-4bba-84f8-47c56b8275d8



## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
