### PR TITLE
fix: repo commit count via pagination

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -555,26 +555,29 @@
       async function fetchGitHubData() {
     const headers = {
         'Authorization': `token ${config.github.token}`,
-        'Accept': 'application/vnd.github.v3+json'
+        'Accept': 'application/vnd.github.inertia-preview+json'
     };
 
     try {
         // Fetch data for the specific repository
-        const [repoData, contributors, prs] = await Promise.all([
+        const [repoData, contributors, prs, projects] = await Promise.all([
             fetch(`${config.github.apiUrl}/repos/${config.github.owner}/${config.github.repo}`, { headers })
                 .then(res => res.json()),
             fetch(`${config.github.apiUrl}/repos/${config.github.owner}/${config.github.repo}/contributors`, { headers })
                 .then(res => res.json()),
             fetch(`${config.github.apiUrl}/repos/${config.github.owner}/${config.github.repo}/pulls?state=all`, { headers })
+                .then(res => res.json()),
+            fetch(`${config.github.apiUrl}/repos/${config.github.owner}/${config.github.repo}/projects`, { headers })
                 .then(res => res.json())
         ]);
 
         // Check if the specific repository is archived or active
-        const isActive = repoData.archived === false;
-        const activeProjectsCount = isActive ? 1 : 0;
+        const isActive = !repoData.archived;
 
         // Fetch total commit count from the repoData
         const defaultBranchCommitsCount = repoData.commits || await getCommitCount(repoData.default_branch);
+        // Count the number of projects associated with the repository
+        const projectCount = Array.isArray(projects) ? projects.length : 0;
 
         state.allContributors = contributors;
         updateFilterCounts(contributors);
@@ -587,7 +590,7 @@
             },
             contributors.length,
             prs.length,
-            activeProjectsCount
+            projectCount
         );
         renderFilterButtons(contributors.length);
         renderContributors(contributors);

--- a/templates/index.html
+++ b/templates/index.html
@@ -551,7 +551,7 @@
               timeout = setTimeout(() => func.apply(this, args), wait);
           };
       }
-
+   
       async function fetchGitHubData() {
     const headers = {
         'Authorization': `token ${config.github.token}`,
@@ -559,7 +559,7 @@
     };
 
     try {
-        // Fetch data only for the specific repository
+        // Fetch data for the specific repository
         const [repoData, contributors, prs] = await Promise.all([
             fetch(`${config.github.apiUrl}/repos/${config.github.owner}/${config.github.repo}`, { headers })
                 .then(res => res.json()),
@@ -573,17 +573,9 @@
         const isActive = repoData.archived === false;
         const activeProjectsCount = isActive ? 1 : 0;
 
-        // Fetch commits from the default branch
-        const defaultBranch = repoData.default_branch || 'main'; // Fallback to 'main' if not provided
-        const commits = await fetch(
-            `${config.github.apiUrl}/repos/${config.github.owner}/${config.github.repo}/commits?sha=${defaultBranch}`,
-            { headers }
-        ).then(res => res.json());
+        // Fetch total commit count from the repoData
+        const defaultBranchCommitsCount = repoData.commits || await getCommitCount(repoData.default_branch);
 
-        const defaultBranchCommitsCount = Array.isArray(commits) ? commits.length : 0;
-
-    
-   
         state.allContributors = contributors;
         updateFilterCounts(contributors);
 
@@ -604,6 +596,30 @@
         showError('Failed to fetch GitHub data');
     }
 }
+
+      async function getCommitCount(branch) {
+          const headers = {
+              'Authorization': `token ${config.github.token}`,
+              'Accept': 'application/vnd.github.v3+json'
+          };
+          const url = `${config.github.apiUrl}/repos/${config.github.owner}/${config.github.repo}/commits?sha=${branch}&per_page=100`;
+          let page = 1;
+          let totalCommits = 0;
+
+          while (true) {
+              const response = await fetch(`${url}&page=${page}`, { headers });
+              const commits = await response.json();
+
+              if (!Array.isArray(commits) || commits.length === 0) {
+                  break;
+              }
+
+              totalCommits += commits.length;
+              page += 1;
+          }
+
+          return totalCommits;
+      }
 
       function renderStats(repoData, contributorsCount, prsCount, activeProjectsCount) {
           const stats = [
@@ -634,7 +650,7 @@
           if (!statsContainer) return;
 
           statsContainer.innerHTML = stats.map(stat => createStatCard(stat)).join('');
-        }
+      }
 
       function createStatCard(stat) {
           return `


### PR DESCRIPTION
## Description
This PR is in reference to PR #35 

## Related Issue

Part of Issue #27 

## Motivation and Context
The total repo commit count was incorrectly displayed as "30" since pagination limit for counting array length fetched via github api is bydefault 30. Fixed that by implementing pagination to the fetched commit count.

## How Has This Been Tested?
Local Device.
Local Host.

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/02a60e39-3dde-47e9-aa1e-e8065c121324)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
