### PR TITLE
feat: added deployment ci/cd to reduce downtime possibility

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,23 @@
+name: Keep Render Service Active
+
+on:
+  schedule:
+    # Runs every 5 minutes
+    - cron: '*/5 * * * *'
+  workflow_dispatch:  # Manual trigger
+
+jobs:
+  ping:
+    name: Ping Service
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Send HTTP Request
+        run: |
+          response=$(curl -s -w "\n%{http_code}" https://sociosell.onrender.com/ || echo "Request failed")
+          echo "Ping executed at $(date)"
+          echo "Response: $response"
+
+      - name: Check Response
+        if: failure()
+        run: echo "Ping attempt failed, but continuing workflow"


### PR DESCRIPTION
## Description

This PR adds new GitHub Actions workflow to prevent your Render deployment (https://sociosell.onrender.com/) from becoming inactive. runs automatically every 5 minutes to ping your deployment URL. This simple but effective solution helps minimize server downtime and cold start delays that users might experience due to Render's 50-second inactivity shutdown policy. The workflow runs on Ubuntu, logs each ping attempt's timestamp, and continues even if a ping fails. requires no additional setup or maintenance.

## Related Issue

Fixes #61 

## Motivation and Context
Improves User / Client Experience 

## How Has This Been Tested?
Tested Locally 

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:

- [x] My code follows the code style of this project
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
